### PR TITLE
Guided tour

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-dom": "16.13.1",
     "react-firebaseui": "^4.1.0",
     "react-github-corner": "^2.5.0",
+    "react-joyride": "^2.3.0",
     "react-redux": "^7.2.2",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.8",

--- a/pages/poll/create.tsx
+++ b/pages/poll/create.tsx
@@ -12,7 +12,7 @@ import {
   OverlayTrigger,
   Tooltip,
 } from "react-bootstrap";
-import { InfoCircleFill } from "react-bootstrap-icons";
+import { InfoCircleFill, QuestionCircleFill } from "react-bootstrap-icons";
 import { useState } from "react";
 import Layout from "../../src/components/Layout";
 import ResponseMessage from "../../src/components/ResponseMessage";
@@ -21,6 +21,7 @@ import { Choice, RocketMeetPoll } from "../../src/models/poll";
 import withprivateAuth from "../../src/utils/privateAuth";
 import { RootState } from "../../src/store/store";
 import { createPoll } from "../../src/utils/api/server";
+import Joyride, { CallBackProps, STATUS, Step, StoreHelpers } from 'react-joyride';
 
 // typings aren't available for react-available-times :(
 
@@ -44,6 +45,41 @@ const Create = (): JSX.Element => {
     type: "",
     msg: "",
   });
+
+  const [tourRun, setTourRun] = useState<boolean>(false);
+
+  // Run automatically for first time users
+  if (typeof window !== 'undefined') {
+    if (localStorage.visited !== 'true') {
+      localStorage.setItem('visited', 'true')
+      setTourRun(true)
+    }
+  }
+
+  const [tourHelpers, setTourHelpers] = useState<StoreHelpers | undefined>(undefined)
+  const tourSteps: Step[] = [
+    {
+      disableBeacon: true,
+      target: '#formPlainTextTitle',
+      content: 'Give your event the title it deserves. Something memorable'
+    },
+    {
+      target: '#formPlainTextDescription',
+      content: 'Add a description to let your invitees know what this is all about.'
+    },
+    {
+      target: '.rat-AvailableTimes_buttons',
+      content: 'Are you an early planner? Use these button to schedule in the future, or past. (ps: Time travel powers not included)'
+    },
+    {
+      target: '.rat-Slider_component',
+      content: 'Click and drag to create a time slots. Repeat to create more of them. These will be the choices that are generated in the poll'
+    },
+    {
+      target: '.create-poll-btn',
+      content: 'Press here when you\'re all done to create the poll and get a sharable link'
+    }
+  ];
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const { value } = e.target;
@@ -136,8 +172,41 @@ const Create = (): JSX.Element => {
     }
   };
 
+  const getTourHelpers = (helpers: StoreHelpers) => {
+    setTourHelpers(helpers);
+  }
+
+  const handleStartTour = (event: React.MouseEvent<SVGElement, MouseEvent>) => {
+    setTourRun(true)
+  }
+
+  const handleJoyrideCallback = (data: CallBackProps) => {
+    const { status, type } = data;
+    const finishedStatuses: string[] = [STATUS.FINISHED, STATUS.SKIPPED];
+
+    console.log(data)
+
+    if (finishedStatuses.includes(status) || type === 'beacon') {
+      setTourRun(false)
+    }
+  }
+
   return (
     <Layout>
+      <Joyride
+        callback={handleJoyrideCallback}
+        getHelpers={getTourHelpers}
+        steps={tourSteps}
+        run={tourRun}
+        continuous={true}
+        showSkipButton={true}
+        showProgress={true}
+        debug={process.env.NODE_ENV === "development"}
+        spotlightClicks={true}
+        styles={
+          { buttonClose: { visibility: "hidden" } }
+        }
+      />
       <Container className="rm-poll-container" fluid>
         <Row className="jumbo-row">
           <div className="jumbo-col-black col-sm-4">

--- a/pages/poll/create.tsx
+++ b/pages/poll/create.tsx
@@ -203,9 +203,12 @@ const Create = (): JSX.Element => {
         showProgress={true}
         debug={process.env.NODE_ENV === "development"}
         spotlightClicks={true}
-        styles={
-          { buttonClose: { visibility: "hidden" } }
-        }
+        styles={{
+          buttonClose: { visibility: "hidden" },
+          options: {
+            primaryColor: "#101010"
+          }
+        }}
       />
       <Container className="rm-poll-container" fluid>
         <Row className="jumbo-row">

--- a/pages/poll/create.tsx
+++ b/pages/poll/create.tsx
@@ -14,6 +14,7 @@ import {
 } from "react-bootstrap";
 import { InfoCircleFill, QuestionCircleFill } from "react-bootstrap-icons";
 import { useState } from "react";
+import Joyride, { CallBackProps, STATUS, Step } from "react-joyride";
 import Layout from "../../src/components/Layout";
 import ResponseMessage from "../../src/components/ResponseMessage";
 import { encrypt } from "../../src/helpers/helpers";
@@ -21,7 +22,6 @@ import { Choice, RocketMeetPoll } from "../../src/models/poll";
 import withprivateAuth from "../../src/utils/privateAuth";
 import { RootState } from "../../src/store/store";
 import { createPoll } from "../../src/utils/api/server";
-import Joyride, { CallBackProps, STATUS, Step, StoreHelpers } from 'react-joyride';
 
 // typings aren't available for react-available-times :(
 
@@ -49,36 +49,38 @@ const Create = (): JSX.Element => {
   const [tourRun, setTourRun] = useState<boolean>(false);
 
   // Run automatically for first time users
-  if (typeof window !== 'undefined') {
-    if (localStorage.visited !== 'true') {
-      localStorage.setItem('visited', 'true')
-      setTourRun(true)
+  if (typeof window !== "undefined") {
+    if (localStorage.visited !== "true") {
+      localStorage.setItem("visited", "true");
+      setTourRun(true);
     }
   }
 
-  const [tourHelpers, setTourHelpers] = useState<StoreHelpers | undefined>(undefined)
   const tourSteps: Step[] = [
     {
       disableBeacon: true,
-      target: '#formPlainTextTitle',
-      content: 'Give your event the memorable title it deserves.'
+      target: "#formPlainTextTitle",
+      content: "Give your event the memorable title it deserves.",
     },
     {
-      target: '#formPlainTextDescription',
-      content: 'Add a description to let your invitees know what this is all about.'
+      target: "#formPlainTextDescription",
+      content:
+        "Add a description to let your invitees know what this is all about.",
     },
     {
-      target: '.rat-AvailableTimes_buttons',
-      content: 'Are you an early planner? Use these button to schedule in the future. (ps: Time travel powers not included)'
+      target: ".rat-AvailableTimes_buttons",
+      content:
+        "Are you an early planner? Use these button to schedule in the future. (ps: Time travel powers not included)",
     },
     {
-      target: '.rat-Slider_component',
-      content: 'Click and drag to create a time slot. You can create more than one. These will be the choices that are generated in the poll'
+      target: ".rat-Slider_component",
+      content:
+        "Click and drag to create a time slot. You can create more than one. These will be the choices that are generated in the poll",
     },
     {
-      target: '.create-poll-btn',
-      content: 'Click here when you\'re all done to get a sharable link'
-    }
+      target: ".create-poll-btn",
+      content: "Click here when you're all done to get a sharable link",
+    },
   ];
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
@@ -172,42 +174,35 @@ const Create = (): JSX.Element => {
     }
   };
 
-  const getTourHelpers = (helpers: StoreHelpers) => {
-    setTourHelpers(helpers);
-  }
+  const handleStartTour = (): void => {
+    setTourRun(true);
+  };
 
-  const handleStartTour = (event: React.MouseEvent<SVGElement, MouseEvent>) => {
-    setTourRun(true)
-  }
-
-  const handleJoyrideCallback = (data: CallBackProps) => {
+  const handleJoyrideCallback = (data: CallBackProps): void => {
     const { status, type } = data;
     const finishedStatuses: string[] = [STATUS.FINISHED, STATUS.SKIPPED];
 
-    console.log(data)
-
-    if (finishedStatuses.includes(status) || type === 'beacon') {
-      setTourRun(false)
+    if (finishedStatuses.includes(status) || type === "beacon") {
+      setTourRun(false);
     }
-  }
+  };
 
   return (
     <Layout>
       <Joyride
         callback={handleJoyrideCallback}
-        getHelpers={getTourHelpers}
         steps={tourSteps}
         run={tourRun}
-        continuous={true}
-        showSkipButton={true}
-        showProgress={true}
+        continuous
+        showSkipButton
+        showProgress
         debug={process.env.NODE_ENV === "development"}
-        spotlightClicks={true}
+        spotlightClicks
         styles={{
           buttonClose: { visibility: "hidden" },
           options: {
-            primaryColor: "#101010"
-          }
+            primaryColor: "#101010",
+          },
         }}
       />
       <Container className="rm-poll-container" fluid>
@@ -246,7 +241,10 @@ const Create = (): JSX.Element => {
               >
                 <InfoCircleFill className="timezone-info-icon" />
               </OverlayTrigger>
-              <QuestionCircleFill className="tour-start-icon" onClick={handleStartTour} />
+              <QuestionCircleFill
+                className="tour-start-icon"
+                onClick={handleStartTour}
+              />
             </Jumbotron>
           </div>
           <div className="col-sm-8">
@@ -264,17 +262,17 @@ const Create = (): JSX.Element => {
                 {!disabled ? (
                   `Create Poll`
                 ) : (
-                    <>
-                      <Spinner
-                        as="span"
-                        animation="border"
-                        size="sm"
-                        role="status"
-                        aria-hidden="true"
-                        className="rm-button-spinner"
-                      />
-                    </>
-                  )}
+                  <>
+                    <Spinner
+                      as="span"
+                      animation="border"
+                      size="sm"
+                      role="status"
+                      aria-hidden="true"
+                      className="rm-button-spinner"
+                    />
+                  </>
+                )}
               </Button>
               <ResponseMessage
                 response={response}

--- a/pages/poll/create.tsx
+++ b/pages/poll/create.tsx
@@ -243,6 +243,7 @@ const Create = (): JSX.Element => {
               >
                 <InfoCircleFill className="timezone-info-icon" />
               </OverlayTrigger>
+              <QuestionCircleFill className="tour-start-icon" onClick={handleStartTour} />
             </Jumbotron>
           </div>
           <div className="col-sm-8">

--- a/pages/poll/create.tsx
+++ b/pages/poll/create.tsx
@@ -61,7 +61,7 @@ const Create = (): JSX.Element => {
     {
       disableBeacon: true,
       target: '#formPlainTextTitle',
-      content: 'Give your event the title it deserves. Something memorable'
+      content: 'Give your event the memorable title it deserves.'
     },
     {
       target: '#formPlainTextDescription',
@@ -69,15 +69,15 @@ const Create = (): JSX.Element => {
     },
     {
       target: '.rat-AvailableTimes_buttons',
-      content: 'Are you an early planner? Use these button to schedule in the future, or past. (ps: Time travel powers not included)'
+      content: 'Are you an early planner? Use these button to schedule in the future. (ps: Time travel powers not included)'
     },
     {
       target: '.rat-Slider_component',
-      content: 'Click and drag to create a time slots. Repeat to create more of them. These will be the choices that are generated in the poll'
+      content: 'Click and drag to create a time slot. You can create more than one. These will be the choices that are generated in the poll'
     },
     {
       target: '.create-poll-btn',
-      content: 'Press here when you\'re all done to create the poll and get a sharable link'
+      content: 'Click here when you\'re all done to get a sharable link'
     }
   ];
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -359,11 +359,11 @@ h4 {
   border-bottom: 3px solid #d3d3d3 !important;
 }
 
-.timezone-info-icon {
+.timezone-info-icon, .tour-start-icon {
   width: 1.3rem;
   height: 1.3rem;
   color: #e0e0e0;
-  margin-top: 2rem;
+  margin: 2rem 0.25rem 0rem 0.25rem;
 }
 
 @media (min-width: 0) and (max-width: 992px) {
@@ -375,10 +375,10 @@ h4 {
     font-size: 1.5rem !important;
   }
 
-  .timezone-info-icon {
+  .timezone-info-icon, .tour-start-icon {
     width: 1rem;
     height: 1rem;
-    margin-top: 1rem;
+    margin: 1rem 0.125rem 0rem 0.125rem;
   }
 }
 


### PR DESCRIPTION
This addresses the issue laid out in #111 
[React-Joyride](https://react-joyride.com/) is used to generate the tour.

There's 5 stages in the tour: Title, Description, AvailableTimes controls, AvailableTimes calendar and the submit button.

A simple localStorage variable is used to detect if the user has already visited the page. (The _poll page is double loading_ - due to some preexisting code. It's noticeable since the popup reloads along with the page)

There's also a help button, so that users can trigger the tour manually. And I matched the color scheme to the res of the site. (This [one line](https://github.com/JadeMaveric/RocketMeet-client/blob/f0e9e830d7c6987a8006841126a89b3b049c53ea/pages/poll/create.tsx#L209) may need to be refactored as part of #56)

I couldn't find any design docs, but I've tried to use the same coding style that was already present. Typescript typings et all (thankfully, joyride provides those)

By default the tour scrolls to the relevant elements, this causes a minor disturbance. The scrolling can be disabled, but a better fix is to adjust the height of the page to the viewport.

The code doesn't affect any existing modules, but I still tested it against a production build. Everything looks fine.
![rocket-meet-guided-tour](https://user-images.githubusercontent.com/12978899/111064834-55aced80-84dc-11eb-8fa1-72ac95fae156.gif)
